### PR TITLE
Test Connections Are Closed In Acceptance Tests

### DIFF
--- a/src/test/java/com/codurance/lightaccess/AcceptanceTest.java
+++ b/src/test/java/com/codurance/lightaccess/AcceptanceTest.java
@@ -67,7 +67,9 @@ public class AcceptanceTest {
 
     @Test
     public void queryNextId() throws Exception {
-        dataSource.getConnection().createStatement().executeUpdate("CREATE SEQUENCE aSequence START WITH 2");
+        Connection connection = dataSource.getConnection();
+        connection.createStatement().executeUpdate("CREATE SEQUENCE aSequence START WITH 2");
+        connection.close();
 
         Integer id = executor.nextId("aSequence", (x) -> x);
 


### PR DESCRIPTION
Since connections are closed by the library instead of the User, we thought it would be important to capture/freeze this behaviour in our Acceptance Tests.